### PR TITLE
fix: harden admin auth

### DIFF
--- a/app/api/admin/login/route.ts
+++ b/app/api/admin/login/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-
-const ADMIN_COOKIE = "admin_session";
+import {
+  ADMIN_COOKIE,
+  sessionToken,
+  verifyAdminPassword,
+} from "@/utils/adminAuth";
 
 export async function POST(request: NextRequest) {
   const secret = process.env.ADMIN_SECRET;
@@ -14,12 +17,12 @@ export async function POST(request: NextRequest) {
 
   const { password } = await request.json();
 
-  if (password !== secret) {
+  if (typeof password !== "string" || !verifyAdminPassword(password, secret)) {
     return NextResponse.json({ error: "Invalid password" }, { status: 401 });
   }
 
   const response = NextResponse.json({ success: true });
-  response.cookies.set(ADMIN_COOKIE, secret, {
+  response.cookies.set(ADMIN_COOKIE, sessionToken(secret), {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
     sameSite: "lax",

--- a/utils/adminAuth.ts
+++ b/utils/adminAuth.ts
@@ -1,6 +1,21 @@
+import crypto from "crypto";
 import { NextRequest, NextResponse } from "next/server";
 
-const ADMIN_COOKIE = "admin_session";
+export const ADMIN_COOKIE = "admin_session";
+
+// Hash both sides so inputs of different lengths can be compared and the
+// comparison time never depends on how many leading characters match.
+function safeEqual(a: string, b: string): boolean {
+  const ha = crypto.createHash("sha256").update(a).digest();
+  const hb = crypto.createHash("sha256").update(b).digest();
+  return crypto.timingSafeEqual(ha, hb);
+}
+
+// The cookie stores this derived token rather than ADMIN_SECRET itself, so a
+// leaked cookie doesn't expose the secret.
+export function sessionToken(secret: string): string {
+  return crypto.createHmac("sha256", secret).update(ADMIN_COOKIE).digest("hex");
+}
 
 export function checkAdminAuth(request: NextRequest): NextResponse | null {
   if (process.env.NODE_ENV !== "production") return null;
@@ -17,9 +32,16 @@ export function checkAdminAuth(request: NextRequest): NextResponse | null {
   const token = request.headers.get("x-admin-token");
   const cookieToken = request.cookies.get(ADMIN_COOKIE)?.value;
 
-  if (token === adminSecret || cookieToken === adminSecret) {
+  if (
+    (token && safeEqual(token, adminSecret)) ||
+    (cookieToken && safeEqual(cookieToken, sessionToken(adminSecret)))
+  ) {
     return null;
   }
 
   return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+}
+
+export function verifyAdminPassword(password: string, secret: string): boolean {
+  return safeEqual(password, secret);
 }


### PR DESCRIPTION
audited all 11 admin routes — auth and slug validation were already consistent everywhere. two fixes: comparisons are now timing-safe, and the session cookie stores an hmac-derived token instead of the raw ADMIN_SECRET (existing sessions get logged out once, just log in again).

til: `a === b` on strings returns early at the first differing character, so an attacker who can measure response times can guess a secret one character at a time. hashing both sides then using crypto.timingSafeEqual makes the comparison take constant time regardless of how close the guess is.