### PR TITLE
feat: similar posts via embeddings

### DIFF
--- a/app/(sidebar)/posts/[slug]/page.tsx
+++ b/app/(sidebar)/posts/[slug]/page.tsx
@@ -1,5 +1,7 @@
 import { getPostContent, getPostMetadata } from "@/utils/content/posts";
+import { getRelatedPosts } from "@/utils/content/related";
 import RenderPost from "@/components/posts/RenderPost";
+import RelatedPosts from "@/components/posts/RelatedPosts";
 import MarkdownContent from "@/components/posts/MarkdownContent";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
@@ -88,6 +90,7 @@ const PostPage = async ({ params }: { params: Params }) => {
       >
         <MarkdownContent content={postContent.content} />
       </RenderPost>
+      <RelatedPosts posts={getRelatedPosts(slug)} />
     </>
   );
 };

--- a/components/posts/RelatedPosts.tsx
+++ b/components/posts/RelatedPosts.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+import type { RelatedPost } from "@/utils/content/related";
+
+const RelatedPosts = ({ posts }: { posts: RelatedPost[] }) => {
+  if (posts.length === 0) return null;
+
+  return (
+    <div className="mt-8 text-xs">
+      <p className="text-light-text/40 dark:text-dark-text/40 mb-1">Similar</p>
+      <ul className="space-y-1">
+        {posts.map((post) => (
+          <li key={post.slug}>
+            <Link
+              href={`/posts/${post.slug}`}
+              className="text-light-text dark:text-dark-text hover:text-light-accent dark:hover:text-dark-accent transition-colors"
+            >
+              {post.title}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default RelatedPosts;

--- a/config/paths.ts
+++ b/config/paths.ts
@@ -10,6 +10,7 @@ const PUBLIC_DIR = path.join(ROOT_DIR, "public");
 export const IMAGES_DIR = path.join(PUBLIC_DIR, "images");
 export const IMAGES_DRAFTS_DIR = path.join(IMAGES_DIR, "drafts");
 export const DATA_DIR = path.join(PUBLIC_DIR, "data");
+export const KNOWLEDGE_MAP_JSON = path.join(DATA_DIR, "knowledge-map.json");
 
 export const LIBRARY_MD = path.join(
   ROOT_DIR,

--- a/scripts/generateKnowledgeMap.ts
+++ b/scripts/generateKnowledgeMap.ts
@@ -15,7 +15,7 @@ import {
   CLUSTERING_UMAP_COMPONENTS,
   SIMILARITY_EDGE_THRESHOLD,
 } from "../config/constants";
-import { DATA_DIR } from "../config/paths";
+import { DATA_DIR, KNOWLEDGE_MAP_JSON } from "../config/paths";
 import type {
   KnowledgeMapOutput,
   ArticleNode,
@@ -24,7 +24,6 @@ import type {
 } from "../types/knowledgeMap";
 import type { ChunkRow } from "../types/chunks";
 import fs from "fs";
-import path from "path";
 
 const sql = neon(process.env.POSTGRES_URL!);
 
@@ -51,7 +50,7 @@ async function generateKnowledgeMap() {
       return;
     }
 
-    const outputPath = path.join(DATA_DIR, "knowledge-map.json");
+    const outputPath = KNOWLEDGE_MAP_JSON;
     const sourceFingerprint = await getSourceFingerprint();
 
     if (fs.existsSync(outputPath)) {

--- a/utils/content/related.ts
+++ b/utils/content/related.ts
@@ -1,0 +1,54 @@
+import fs from "fs";
+import { KNOWLEDGE_MAP_JSON } from "@/config/paths";
+import type { KnowledgeMapOutput } from "@/types/knowledgeMap";
+
+export interface RelatedPost {
+  slug: string;
+  title: string;
+  similarity: number;
+}
+
+// slug → most similar posts, built once from the knowledge map's similarity
+// edges (already thresholded at build time) and reused across pages.
+let relatedBySlug: Map<string, RelatedPost[]> | null = null;
+
+function buildIndex(): Map<string, RelatedPost[]> {
+  const index = new Map<string, RelatedPost[]>();
+  if (!fs.existsSync(KNOWLEDGE_MAP_JSON)) return index;
+
+  const map: KnowledgeMapOutput = JSON.parse(
+    fs.readFileSync(KNOWLEDGE_MAP_JSON, "utf8")
+  );
+
+  const add = (from: number, to: number, similarity: number) => {
+    const source = map.data[from];
+    const target = map.data[to];
+    if (!source || !target || source.postSlug === target.postSlug) return;
+    let related = index.get(source.postSlug);
+    if (!related) {
+      related = [];
+      index.set(source.postSlug, related);
+    }
+    related.push({
+      slug: target.postSlug,
+      title: target.postTitle,
+      similarity,
+    });
+  };
+
+  for (const [a, b, similarity] of map.similarityEdges) {
+    add(a, b, similarity);
+    add(b, a, similarity);
+  }
+
+  for (const posts of index.values()) {
+    posts.sort((x, y) => y.similarity - x.similarity);
+  }
+
+  return index;
+}
+
+export function getRelatedPosts(slug: string, limit = 4): RelatedPost[] {
+  relatedBySlug ??= buildIndex();
+  return (relatedBySlug.get(slug) ?? []).slice(0, limit);
+}


### PR DESCRIPTION
each post now lists its 4 most similar posts, computed from the knowledge map's cosine-similarity edges that the build already generates — zero runtime db queries, the index is built once from the json and cached in module scope.

til: module-level variables in next.js server code survive across requests within the same server process, so a lazily-built index like this is effectively a free memo — but it also means you should never put per-request state there.